### PR TITLE
Nil checks to prevent potential client-sided errors in cl_doors.lua t…

### DIFF
--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -74,10 +74,12 @@ function meta:drawOwnableInfo()
     end
 
     if self:IsVehicle() then
-        local driver = self:GetDriver()
-        if driver:IsPlayer() then
-            table.insert(doorInfo, DarkRP.getPhrase("driver", driver:Nick()))
-        end
+		if self.GetDriver then
+			local driver = self:GetDriver()
+			if driver and driver:IsPlayer() then
+				table.insert(doorInfo, DarkRP.getPhrase("driver", driver:Nick()))
+			end
+		end
     end
 
     local x, y = ScrW() / 2, ScrH() / 2


### PR DESCRIPTION
…ogether with base SCars installation

With default DarkRP settings certain cars can cause errors in door system. Workshop addons installed:
 - SCars Basic [https://steamcommunity.com/sharedfiles/filedetails/?id=104487316]
 - SCars Slim [https://steamcommunity.com/sharedfiles/filedetails/?id=104483020]
 - SCars Extra [https://steamcommunity.com/sharedfiles/filedetails/?id=104492363]